### PR TITLE
1路線のみの会社グループで路線名をそのまま表示

### DIFF
--- a/components/RouteInfoModal.tsx
+++ b/components/RouteInfoModal.tsx
@@ -225,13 +225,15 @@ export const RouteInfoModal = ({
                   各線の種別
                 </h2>
                 <div className="flex flex-col gap-0.5">
-                  {linesByCompany.map(({ stop }) => (
+                  {linesByCompany.map(({ lineNames, stop }) => (
                     <div
                       key={stop.line?.company?.id}
                       className="flex items-center justify-between py-1 px-3 rounded-lg bg-gray-50"
                     >
                       <span className="text-sm text-gray-700">
-                        {stop.line?.company?.nameShort}線
+                        {lineNames.length === 1
+                          ? lineNames[0]
+                          : `${stop.line?.company?.nameShort}線`}
                       </span>
                       <span
                         className="text-sm font-bold"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* ルート情報表示で、複数の路線を含むルートの表現が改善されました。単一の路線名の場合はその名前をそのまま表示し、複数の路線名がある場合は事業者の短縮名と「線」の組み合わせで表示するようになります。これにより、複雑な経路情報がより正確かつ分かりやすく表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->